### PR TITLE
【Fixed】お気に入り機能を作る２（一覧ページ）

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,4 +1,7 @@
 class FavoritesController < ApplicationController
+  def index
+    @favorites = current_user.favorites
+  end
   def create
     @post = Post.find(params[:post_id])
     favorite = current_user.favorites.build(post_id: params[:post_id])

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,9 @@
+<h1>お気に入り一覧</h1>
+<div>
+  <% @favorites.each do |favorite| %>
+    <ul id="favorite-btn-<%= favorite.post.id %>" class="list-group">
+      <li class="list-group-item"><%= image_tag favorite.post.image %></li>
+      <%= render partial: 'favorites/favorite', locals: { post: favorite.post } %>
+    </ul>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
     end
     resources :favorites, only: [:create, :destroy]
   end
+  resources :favorites, only: [:index]
 end


### PR DESCRIPTION
#25
<br>
### 新たな課題（メモ）
お気に入り一覧ページ内でお気に入りを解除すると、
画像はリアルタイムで表示されなくなるが、
下のように「登録」「解除」ボタン（リンク）が残る。
補足：今は数字をクリックすることで登録・解除するようにしてる
<br>
<img width="331" alt="スクリーンショット 2021-08-11 2 15 37" src="https://user-images.githubusercontent.com/83779040/128905516-47ddefb0-97b1-47d0-be0e-0bd6971e67cf.png">

